### PR TITLE
[Cursor] Simplify blog styling by removing teal color from most elements

### DIFF
--- a/app/components/blog/BlogList.tsx
+++ b/app/components/blog/BlogList.tsx
@@ -34,7 +34,7 @@ export default function BlogList({ posts }: BlogListProps) {
               </div>
             )}
             
-            <h2 className="text-xl font-semibold mb-2 text-white group-hover:text-teal-400 transition-colors">
+            <h2 className="text-xl font-semibold mb-2 text-white group-hover:text-white transition-colors">
               {post.title}
             </h2>
             

--- a/app/components/blog/BlogPost.tsx
+++ b/app/components/blog/BlogPost.tsx
@@ -23,7 +23,7 @@ export default function BlogPost({ post }: BlogPostProps) {
     if (post.content) {
       console.log('Using Markdown content');
       return (
-        <div className="prose prose-lg prose-invert w-full !max-w-full prose-p:text-gray-200 prose-p:leading-relaxed prose-p:text-justify prose-headings:text-teal-400 prose-strong:text-teal-400 prose-em:text-gray-300 prose-code:bg-gray-900 prose-code:text-gray-200 prose-blockquote:border-teal-500 prose-blockquote:text-gray-300 prose-a:text-teal-400 prose-li:text-gray-200 prose-li:leading-relaxed prose-pre:bg-gray-900 prose-pre:rounded-lg">
+        <div className="prose prose-lg prose-invert w-full !max-w-full prose-p:text-gray-200 prose-p:leading-relaxed prose-p:text-justify prose-headings:text-gray-200 prose-strong:text-gray-200 prose-em:text-gray-300 prose-code:bg-gray-900 prose-code:text-gray-200 prose-blockquote:border-gray-500 prose-blockquote:text-gray-300 prose-a:text-teal-400 prose-li:text-gray-200 prose-li:leading-relaxed prose-pre:bg-gray-900 prose-pre:rounded-lg">
           <MarkdownToJSX>
             {post.content}
           </MarkdownToJSX>
@@ -58,11 +58,11 @@ export default function BlogPost({ post }: BlogPostProps) {
   return (
     <div className="container mx-auto pb-12">
       <div className="px-4 md:px-6 lg:px-8">
-        <Link href="/blog" className="text-primary-600 hover:text-primary-800 dark:text-primary-400 dark:hover:text-primary-200 inline-block mb-8">
+        <Link href="/blog" className="text-teal-400 hover:text-teal-300 inline-block mb-8">
           ← Back to all articles
         </Link>
         
-        <h1 className="text-4xl md:text-5xl font-bold mb-6 text-teal-400">
+        <h1 className="text-4xl md:text-5xl font-bold mb-6 text-gray-200">
           {post.title}
         </h1>
         

--- a/app/components/blog/FeaturedBlogPost.tsx
+++ b/app/components/blog/FeaturedBlogPost.tsx
@@ -77,7 +77,7 @@ export default function FeaturedBlogPost({ post }: FeaturedBlogPostProps) {
                   <time dateTime={post.sys.createdAt} className="text-gray-200 text-sm backdrop-blur-sm bg-black/20 px-2 py-1 rounded">{formattedDate}</time>
                 </div>
                 
-                <h2 className="text-3xl font-bold text-white mb-2 group-hover:text-teal-400 transition-colors drop-shadow-lg">
+                <h2 className="text-3xl font-bold text-white mb-2 group-hover:text-white transition-colors drop-shadow-lg">
                   {post.title}
                 </h2>
               </div>


### PR DESCRIPTION
   ## Changes
   - Remove teal color from headings in blog post content
   - Remove teal color from bold text in blog post content
   - Change blockquote border color from teal to gray
   - Keep teal color only for links and interactive elements
   - Remove teal hover effect on post titles in blog listings
   - Maintain consistent styling across all blog components
   - Improve readability with cleaner color scheme
   
   ## Testing
   - Verified styling changes in the blog post view
   - Confirmed links still appear in teal for good usability
   - Tested blog listing page to ensure consistent styling
   - Checked featured blog post component styling
   - Verified changes look good on mobile and desktop viewports
   
   ## Notes
   - Styling is now cleaner and less busy as requested
   - No functional changes, only visual improvements
   - Maintained teal accent for interactive elements (links, buttons) for good UX