### PR TITLE
[Cursor] Merge dev into main - Update Next.js image configuration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -24,22 +24,34 @@ const nextConfig = {
    * Images Configuration
    * Controls how Next.js handles and optimizes images.
    * 
-   * ⚠️ CAUTION: The 'domains' array has caused merge conflicts.
-   * When adding new domains, always:
-   * 1. Check if the domain already exists in the array
+   * ⚠️ CAUTION: The image configuration has caused merge conflicts.
+   * When adding new patterns, always:
+   * 1. Check if the pattern already exists
    * 2. Add comments explaining what each domain is used for
    * 3. Make sure to merge with the latest changes from dev branch
    * 
-   * Current domains:
+   * Current remote patterns:
    * - img.youtube.com: For YouTube thumbnail images
    * - i.ytimg.com: For YouTube video thumbnails and previews
    * - images.ctfassets.net: For Contentful CMS images
    */
   images: {
-    domains: [
-      'img.youtube.com',     // YouTube thumbnail images
-      'i.ytimg.com',         // YouTube video thumbnails and previews
-      'images.ctfassets.net' // Contentful CMS images
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'img.youtube.com',
+        pathname: '**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'i.ytimg.com',
+        pathname: '**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'images.ctfassets.net',
+        pathname: '**',
+      },
     ],
   },
 


### PR DESCRIPTION
   ## Changes
   - Update Next.js image configuration to use remotePatterns instead of domains
   - Fix deprecation warning by following Next.js best practices
   - Improve security by explicitly defining protocols and pathnames for image sources
   - Maintain support for all existing image domains (YouTube, Contentful)

   ## Testing
   - Verified all external images load correctly
   - Confirmed the deprecation warning is removed in the dev environment
   - Tested all pages to ensure they render properly with the new configuration

   ## Notes
   - This is a low-risk improvement to code quality and security
   - The remotePatterns approach is more explicit about allowed image sources
   - No functional changes to the application