### PR TITLE
[Cursor] Refine cursor gradient effect for more subtle UI

### DIFF
--- a/components/cursor-gradient.tsx
+++ b/components/cursor-gradient.tsx
@@ -27,7 +27,7 @@ export function CursorGradient() {
       ref={gradientRef}
       className="pointer-events-none fixed inset-0 z-30 transition-opacity duration-300"
       style={{
-        background: `radial-gradient(333px circle at var(--x, 100px) var(--y, 100px), rgba(13, 148, 136, 0.15), transparent 80%)`,
+        background: `radial-gradient(166px circle at var(--x, 100px) var(--y, 100px), rgba(13, 148, 136, 0.15), transparent 85%)`,
       }}
     />
   )


### PR DESCRIPTION
## Changes
- Reduced cursor gradient radius from 333px to 166px (exactly half)
- Adjusted fade ratio from 80% to 85% for smoother edge blending
- Maintained the teal color and glow behavior while making it less obtrusive

## Testing
- Verified the cursor gradient works properly at all screen sizes
- Confirmed the more subtle effect follows cursor movement smoothly
- Tested on development server to ensure the visual effect is more refined
- Checked compatibility across browsers

## Notes
- This change creates a more elegant, subtle user experience
- No breaking changes or dependencies
- Pure UI enhancement with no functional changes